### PR TITLE
adding Zereth Mortis rares

### DIFF
--- a/AnnounceRare.lua
+++ b/AnnounceRare.lua
@@ -54,7 +54,8 @@ AR.zones = {
 	1527, -- uldum
 	1571, -- uldum (vision zone)
 	1543, -- the maw
-	1961 -- kothria
+	1961, -- kothria
+	1970 -- zereth mortis
 }
 local band = bit.band
 local ceil = math.ceil

--- a/AnnounceRare.toc
+++ b/AnnounceRare.toc
@@ -1,7 +1,7 @@
 ## Interface: 90105
-## Author: Crackpot
+## Author: Crackpot, Zereth Mortis by pjbehr87
 ## Title: Announce Rare
-## Version: 3.2.10
+## Version: 3.3.0
 ## Notes: Announce rares to general chat.
 ## SavedVariables: AnnounceRareDB
 ## OptionalDeps: TomTom

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Announce Rare For 9.1
+# Announce Rare For 9.2
 
 This is a simple addon to assist others in the same zone as you when you find a rare. It will announce the rare's name, current health, engaged or not, coordinates, and provide a push pin to quickly locate the mob. Death announcements are also provided so others won't waste their time coming to your location only to find a death mob.
 
@@ -30,3 +30,7 @@ The folowwing is an updated list of zones where rares are currently being tracke
 ### Patch 9.1 - _Chains of Domination_
 
 * [Korthia, the City of Secrets](https:_www.wowhead.com/zone=13570/korthia)
+
+### Patch 9.2 - _Eternity's End_
+
+* [Zereth Mortis](https://www.wowhead.com/zereth-mortis)

--- a/RareDB.lua
+++ b/RareDB.lua
@@ -979,6 +979,127 @@ function AR:LoadRares()
         [179735] = {
             ["name"] = L["Torglluun"],
             ["announced"] = false
+        },
+        -- Zereth Mortis (From: https://www.wowhead.com/guides/rare-spawn-treasure-locations-loot-zereth-mortis)
+        [178778] = {
+            ["name"] = L["Gluttonous Overgrowth"],
+            ["announced"] = false
+        },
+        [183746] = {
+            ["name"] = L["Otiosen"],
+            ["announced"] = false
+        },
+        [178229] = {
+            ["name"] = L["Feasting"],
+            ["announced"] = false
+        },
+        [180917] = {
+            ["name"] = L["Destabilized Core"],
+            ["announced"] = false
+        },
+        [183927] = {
+            ["name"] = L["Sand Matriarch Ileus"],
+            ["announced"] = false
+        },
+        [183737] = {
+            ["name"] = L["Xy'rath the Covetous"],
+            ["announced"] = false
+        },
+        [179006] = {
+            ["name"] = L["Akkaris"],
+            ["announced"] = false
+        },
+        [183596] = {
+            ["name"] = L["Chitali the Eldest"],
+            ["announced"] = false
+        },
+        [183925] = {
+            ["name"] = L["Tahkwitz"],
+            ["announced"] = false
+        },
+        [183722] = {
+            ["name"] = L["Sorranos"],
+            ["announced"] = false
+        },
+        [179043] = {
+            ["name"] = L["Orixal"],
+            ["announced"] = false
+        },
+        [184409] = {
+            ["name"] = L["Euv'ouk"],
+            ["announced"] = false
+        },
+        [183747] = {
+            ["name"] = L["Vitiane"],
+            ["announced"] = false
+        },
+        [178563] = {
+            ["name"] = L["Hadeon the Stonebreaker"],
+            ["announced"] = false
+        },
+        [182318] = {
+            ["name"] = L["General Zarathura"],
+            ["announced"] = false
+        },
+        [178963] = {
+            ["name"] = L["Gorkek"],
+            ["announced"] = false
+        },
+        [181249] = {
+            ["name"] = L["Tethos"],
+            ["announced"] = false
+        },
+        [184413] = {
+            ["name"] = L["Shifting Stargorger"],
+            ["announced"] = false
+        },
+        [180746] = {
+            ["name"] = L["Protector of the First Ones"],
+            ["announced"] = false
+        },
+        [178508] = {
+            ["name"] = L["Mother Phestis"],
+            ["announced"] = false
+        },
+        [180924] = {
+            ["name"] = L["Garudeon"],
+            ["announced"] = false
+        },
+        [183646] = {
+            ["name"] = L["Furidian"],
+            ["announced"] = false
+        },
+        [180978] = {
+            ["name"] = L["Hirukon"],
+            ["announced"] = false
+        },
+        [183764] = {
+            ["name"] = L["Zatojin"],
+            ["announced"] = false
+        },
+        [183814] = {
+            ["name"] = L["Otaris the Provoked"],
+            ["announced"] = false
+        },
+        [183953] = {
+            ["name"] = L["Corrupted Architect"],
+            ["announced"] = false
+        },
+        [183748] = {
+            ["name"] = L["Helmix"],
+            ["announced"] = false
+        },
+        [181360] = {
+            ["name"] = L["Vexis"],
+            ["announced"] = false
+        },
+        [183516] = {
+            ["name"] = L["The Engulfer"],
+            ["announced"] = false
+        },
+        [182158] = {
+            ["name"] = L["Reanimatrox Marzan"],
+            ["announced"] = false
         }
     }
 end


### PR DESCRIPTION
For some reason Reanimatrox Marzan was missed on wowhead. I happened to see it in game while I was testing my changes and it didn't pop up. So I added it to the list.